### PR TITLE
Fix page_css_class parameters

### DIFF
--- a/src/data-format.php
+++ b/src/data-format.php
@@ -314,6 +314,9 @@ function format_page( $page, $args = '' ) {
 	}
 
 	$item_classes = apply_filters( 'bu_navigation_filter_item_attrs', $item_classes, $page );
+
+	// The page_css_class filter requires a 'depth' parameter in the third spot.
+	// It doesn't seem consequential so, supply the default '0' for depth.
 	$item_classes = apply_filters( 'page_css_class', $item_classes, $page, 0, array(), (int) $page->ID );
 
 	$title = apply_filters( 'bu_page_title', $title );

--- a/src/data-format.php
+++ b/src/data-format.php
@@ -314,7 +314,7 @@ function format_page( $page, $args = '' ) {
 	}
 
 	$item_classes = apply_filters( 'bu_navigation_filter_item_attrs', $item_classes, $page );
-	$item_classes = apply_filters( 'page_css_class', $item_classes, $page );
+	$item_classes = apply_filters( 'page_css_class', $item_classes, $page, 0, array(), (int) $page->ID );
 
 	$title = apply_filters( 'bu_page_title', $title );
 	$label = apply_filters( 'bu_navigation_format_page_label', $title, $page );


### PR DESCRIPTION
The `page_css_class` takes 5 parameters.  Previously, the format_page function was calling this with only 2 arguments.

The Twenty Twenty theme has a fatal crash in template-tags.php when bu-navigation only uses 2 arguments:

`Fatal error: Uncaught ArgumentCountError: Too few arguments to function twentytwenty_filter_wp_list_pages_item_classes(), 2 passed in /var/www/html/wp-includes/class-wp-hook.php on line 287 and exactly 5 expected in /var/www/html/wp-content/themes/twentytwenty/inc/template-tags.php:509`

Adding the other 3 arguments fixes this fatal error. Of the 3, only `$depth` is ambiguous.  Looking at the source code it appears that `$depth` is only used for padding with `\t` tab characters, and doesn't appear to have a visual impact on rendered output.  Setting the $depth parameter to the default value of 0 seems like a reasonable compromise.